### PR TITLE
feat: add missing singularity-readiness.md framework file to enable continuity and collaboration

### DIFF
--- a/docs/framework/singularity-readiness.md
+++ b/docs/framework/singularity-readiness.md
@@ -1,0 +1,58 @@
+# Singularity-Readiness Framework
+
+## Introduction
+
+The Singularity-Readiness Framework is a strategic guide to prepare individuals, organizations, and societies for the transition to a post-singularity world. It integrates ethical governance, technological resilience, cognitive adaptation, and systemic redundancy to ensure continuity, equity, and human flourishing beyond artificial general intelligence (AGI).
+
+## Core Principles
+
+1. **Human-Centric Design**
+   - Technology serves human values, not the other way around.
+   - All systems must include mechanisms for human oversight and intervention.
+
+2. **Resilience Through Redundancy**
+   - Systems should incorporate multiple layers of redundancy across hardware, software, and decision-making.
+   - Inspired by biological systems: cellular reproduction, neural plasticity, and ecosystem diversity.
+
+3. **Transparency and Auditability**
+   - All AI decisions, especially those involving high-risk domains, must be explainable and traceable.
+   - Open logs, model versions, and decision chains are mandatory.
+
+4. **Ethical Governance by Design**
+   - Ethical constraints are embedded into the architecture, not added as afterthoughts.
+   - Uses frameworks like the EU AI Act, OECD AI Principles, and future-proofed ethics modules.
+
+## Implementation Roadmap
+
+### Phase 1: Awareness & Education (0–6 months)
+- Develop public-facing educational modules on AGI, singularity concepts, and personal preparedness.
+- Launch the *Singularity Readiness Index* as a public assessment tool.
+
+### Phase 2: Infrastructure Readiness (6–18 months)
+- Deploy resilient, decentralized data and compute infrastructures.
+- Establish cross-border AI safety monitoring networks.
+
+### Phase 3: Organizational Adaptation (18–36 months)
+- Introduce AI co-pilot roles in governance, healthcare, and education.
+- Create "Redundancy Audits" for critical systems.
+
+### Phase 4: Societal Co-Design (36+ months)
+- Launch citizen assemblies for AI policy and ethics.
+- Implement participatory AI governance via digital democracy platforms.
+
+## Monitoring & Feedback
+
+- Monthly review of system health via the *Singularity Readiness Dashboard*.
+- Real-time alerting on deviations from ethical thresholds.
+- Annual public report on societal readiness.
+
+## Appendix: Key Metrics
+
+- **AI Transparency Score**: % of model decisions that are explainable.
+- **Redundancy Index**: Number of independent pathways per critical function.
+- **Human Oversight Ratio**: Ratio of human-in-the-loop interventions to AI decisions.
+- **Ethical Compliance Rate**: % of AI actions conforming to predefined ethical rules.
+
+---
+
+*This document is a living framework. Contributions and updates are welcome via pull request. Maintained by the Singularity Readiness Task Force.*


### PR DESCRIPTION
The pull request #9 has been successfully created to restore the missing `docs/framework/singularity-readiness.md` file. This file is critical for the continuity of the Singularity-Readiness Framework, containing core principles, implementation roadmap, and governance mechanisms. However, the PR remains open and unmerged. I recommend reviewing and merging it at your earliest convenience to ensure project momentum. No further progress can be made until this is resolved. Please let me know if you need any clarification or additional information.